### PR TITLE
Fixed the creation of the template cache keys in the blc:cache processor

### DIFF
--- a/src/main/java/org/broadleafcommerce/presentation/cache/service/SimpleCacheKeyResolver.java
+++ b/src/main/java/org/broadleafcommerce/presentation/cache/service/SimpleCacheKeyResolver.java
@@ -50,7 +50,7 @@ public class SimpleCacheKeyResolver implements TemplateCacheKeyResolverService {
         StringBuilder sb = new StringBuilder();
         sb.append(cacheKey);
         String attributeDocName = getStringValue("templateName", tagAttributes, true, context);
-        sb.append("_" + (attributeDocName == null ? documentName : attributeDocName));
+        sb.append("_" + (attributeDocName == null || attributeDocName.equals("") ? documentName : attributeDocName));
         sb.append("_" + (lineNumber == null ? 0 : lineNumber));
         return sb.toString();
     }


### PR DESCRIPTION
The creation of the cache key wouldn't use the document name ever because even if the `templateName` attribute didn't exist on the element the method to get the value would always return an empty string but the check was to see if it was null. Having this happen would cause cache key collisions that would result in the wrong template being pulled from the cache