### PR TITLE
Wrap the Spring BindStatus in our own implementation

### DIFF
--- a/src/main/java/org/broadleafcommerce/presentation/model/BroadleafBindStatus.java
+++ b/src/main/java/org/broadleafcommerce/presentation/model/BroadleafBindStatus.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * BroadleafCommerce Common Presentation
+ * %%
+ * Copyright (C) 2009 - 2017 Broadleaf Commerce
+ * %%
+ * Licensed under the Broadleaf Fair Use License Agreement, Version 1.0
+ * (the "Fair Use License" located  at http://license.broadleafcommerce.org/fair_use_license-1.0.txt)
+ * unless the restrictions on use therein are violated and require payment to Broadleaf in which case
+ * the Broadleaf End User License Agreement (EULA), Version 1.1
+ * (the "Commercial License" located at http://license.broadleafcommerce.org/commercial_license-1.1.txt)
+ * shall apply.
+ * 
+ * Alternatively, the Commercial License may be replaced with a mutually agreed upon license (the "Custom License")
+ * between you and Broadleaf Commerce. You may not use this file except in compliance with the applicable license.
+ * #L%
+ */
+package org.broadleafcommerce.presentation.model;
+
+import org.springframework.validation.Errors;
+
+/**
+ * @author Jeff Fischer
+ */
+public interface BroadleafBindStatus {
+
+    String getPath();
+    String getExpression();
+    Object getValue();
+    Class<?> getValueType();
+    Object getActualValue();
+    String getDisplayValue();
+
+    boolean isError();
+    String[] getErrorCodes();
+    String getErrorCode();
+    String[] getErrorMessages();
+    String getErrorMessage();
+    String getErrorMessagesAsString(String delimiter);
+    Errors getErrors();
+
+}

--- a/src/main/java/org/broadleafcommerce/presentation/model/BroadleafTemplateContext.java
+++ b/src/main/java/org/broadleafcommerce/presentation/model/BroadleafTemplateContext.java
@@ -95,7 +95,7 @@ public interface BroadleafTemplateContext {
     /**
      * @return Gets the current Spring {@link BindStatus} for {@code attributeValue}
      */
-    public BindStatus getBindStatus(String attributeValue);
+    public BroadleafBindStatus getBindStatus(String attributeValue);
     
     /**
      * @return The current HttpServletRequest if it exists or null otherwise


### PR DESCRIPTION
In Spring 5+, they have changed the package of the `BindStatus` meant to hold Spring-specific information. In order to be compatible with both Spring 4 and Spring 5, we cannot expose this `BindStatus` class directly.