### PR TITLE
Migrate from Java EE to Jakarta EE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 properties(commonModuleJobProps())
-buildBroadleafModule(params)
+buildBroadleafModule(params, false, 'maven-jdk17')

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <project.uri>${project.baseUri}</project.uri>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>6.0.6</spring.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:BroadleafCommerce/CommonPresentation.git</connection>
@@ -88,7 +87,6 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <project.uri>${project.baseUri}</project.uri>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>        
-        <spring.version>5.3.23</spring.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.version>6.0.6</spring.version>
     </properties>
     <scm>
         <connection>scm:git:git@github.com:BroadleafCommerce/CommonPresentation.git</connection>
@@ -86,9 +86,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/org/broadleafcommerce/presentation/cache/service/SimpleCacheKeyResolver.java
+++ b/src/main/java/org/broadleafcommerce/presentation/cache/service/SimpleCacheKeyResolver.java
@@ -35,7 +35,7 @@ public class SimpleCacheKeyResolver implements TemplateCacheKeyResolverService {
      * If cacheKey is null, only the templateName is returned.
      * 
      * If cacheKey is "none" then null will be returned causing the template not to be cached.
-     * @param the tag name that the cache processor is running in
+     * @param tagName the tag name that the cache processor is running in
      * @param tagAttributes the attributes used in the tag or ones added by the cache processor
      * @param documentName the name of the template
      * @param lineNumber the line that the cache processor is on

--- a/src/main/java/org/broadleafcommerce/presentation/model/BroadleafTemplateContext.java
+++ b/src/main/java/org/broadleafcommerce/presentation/model/BroadleafTemplateContext.java
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.support.BindStatus;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Utility class to be used to do various functions on and around the template


### PR DESCRIPTION
**Description**
For a correct migration from Java EE to Jakarta EE, needed to update the CommonPresentation module:
- replaced javax with jakarta; 
- clean code.

**QA Link**
[QA-4929](https://github.com/BroadleafCommerce/QA/issues/4929)

Depend On #https://github.com/BroadleafCommerce/ModuleParent/pull/23
